### PR TITLE
Remove encoding header.

### DIFF
--- a/features/step_definitions/game_steps.rb
+++ b/features/step_definitions/game_steps.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 Dado /^o jogo tem as possíveis palavras para sortear:$/ do |words_table|
   words = words_table.rows.map(&:last).join(" ")
   set_rafflable_words(words)

--- a/lib/game.rb
+++ b/lib/game.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 require_relative 'cli_ui'
 require_relative 'word_raffler'
 

--- a/lib/game_flow.rb
+++ b/lib/game_flow.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 require_relative 'cli_ui'
 require_relative 'game'
 

--- a/lib/word_raffler.rb
+++ b/lib/word_raffler.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 # Classe responsável por sortear uma palavra de uma dada lista de
 # palavras.
 #

--- a/spec/game_flow_spec.rb
+++ b/spec/game_flow_spec.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 require 'spec_helper'
 require 'game_flow'
 

--- a/spec/game_spec.rb
+++ b/spec/game_spec.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 require 'spec_helper'
 require 'game'
 

--- a/spec/word_raffler_spec.rb
+++ b/spec/word_raffler_spec.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 require 'spec_helper'
 require 'word_raffler'
 


### PR DESCRIPTION
Since [Ruby 2.0](https://www.ruby-lang.org/en/news/2013/02/24/ruby-2-0-0-p0-is-released/) the default encoding is UTF-8, making this config redundant.

Depends on #2 