### PR TITLE
Update Ruby version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 rvm:
   - 2.2.2
   - 2.0.0
-  - 1.9.3
 
 script: "bundle exec rspec & bundle exec cucumber"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 rvm:
-  - 2.2.2
-  - 2.0.0
+  - 2.5.1
+  - 2.4.4
 
 script: "bundle exec rspec & bundle exec cucumber"


### PR DESCRIPTION
This PR updates Ruby in the Travis build to the [most updated versions](https://www.ruby-lang.org/en/downloads/releases/) (2.5.1 and 2.4.4) and removes Ruby 1.9.3 support (Ruby 2.0 was released in 2013 and dropping 1.9.3 support will enable updating some Gems like [Cucumber](https://rubygems.org/gems/cucumber) to the latest version).