### PR TITLE
Remove RSpec color option.

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,2 @@
 --require spec_helper
---color
 --format progress


### PR DESCRIPTION
It's enabled by default since version 3.6.