### PR TITLE
Replace $: with $LOAD_PATH

### DIFF
--- a/bin/forca
+++ b/bin/forca
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-$:.unshift File.join(File.dirname(__FILE__), "..", "lib")
+$LOAD_PATH.unshift File.join(File.dirname(__FILE__), "..", "lib")
 
 require 'game_flow'
 


### PR DESCRIPTION
- $LOAD_PATH is way more explicit than $:
- prepend (inverse of append) is easier to understand