### PR TITLE
Remove redundant "require spec_helper"

### DIFF
--- a/spec/game_flow_spec.rb
+++ b/spec/game_flow_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'game_flow'
 
 RSpec.describe GameFlow do

--- a/spec/game_spec.rb
+++ b/spec/game_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'game'
 
 RSpec.describe Game do

--- a/spec/word_raffler_spec.rb
+++ b/spec/word_raffler_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'word_raffler'
 
 RSpec.describe WordRaffler do


### PR DESCRIPTION
RSpec now has a config in `.rspec` that requires `spec_helper` automatically