### PR TITLE
Replace `have_output including` with `.output`

### DIFF
--- a/features/step_definitions/game_steps.rb
+++ b/features/step_definitions/game_steps.rb
@@ -40,7 +40,7 @@ end
 
 Então /^o jogo termina com a seguinte mensagem na tela:$/ do |text|
   expect(last_command_started).to be_successfully_executed
-  expect(last_command_started).to have_output including(text)
+  expect(last_command_started.output).to include(text)
 end
 
 Então /^o jogo mostra que eu adivinhei uma letra com sucesso$/ do


### PR DESCRIPTION
The new API is a bit confusing for checking if the output includes a text. The book will use the RSpec String matcher instead.